### PR TITLE
Fix ReflectionTypeLoadException method 1: internal Patcher

### DIFF
--- a/HarmonyPatcher.cs
+++ b/HarmonyPatcher.cs
@@ -7,7 +7,7 @@ namespace PopulationDemographics
     /// <summary>
     /// Harmony patching
     /// </summary>
-    public class HarmonyPatcher
+    internal class HarmonyPatcher
     {
         private const string HarmonyId = "com.github.rcav8tr.PopulationDemographics";
         private static Harmony _harmony;


### PR DESCRIPTION
Here is the first possible solution to rcav8tr/PopulationDemographics#1:

Fixes issue drok/Harmony-CitiesSkylines#9 which causes the Exception below
when the mod is loaded before Harmony, or with Harmony absent.

```
ReflectionTypeLoadException: The classes in the module cannot be loaded.
  at (wrapper managed-to-native) System.Reflection.Assembly:GetTypes (bool)
  at System.Reflection.Assembly.GetExportedTypes () [0x00000] in <filename unknown>:0
  at ColossalFramework.Plugins.PluginManager+PluginInfo.AddAssembly (System.Reflection.Assembly asm) [0x00000] in <filename unknown>:0
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:LogException(Exception)
ColossalFramework.Plugins.PluginInfo:AddAssembly(Assembly)
ColossalFramework.Plugins.PluginManager:LoadDependenciesRecursive(Assembly, Dictionary`2, Dictionary`2, List`1)
ColossalFramework.Plugins.PluginManager:LoadDependencies(Dictionary`2, Dictionary`2)
ColossalFramework.Plugins.PluginManager:LoadAssemblies(Dictionary`2)
ColossalFramework.Plugins.PluginManager:LoadPlugins()
Starter:Awake()
```